### PR TITLE
feat: require Poetry >= 1.2 for proper version isolation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,63 @@
+name: tests
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: install bats
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bats
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: unit tests
+        run: bash test/run.sh --unit
+
+      # Latest patch of every Poetry minor >= 1.2, auto-discovered from PyPI.
+      # New release → list changes → cache key changes → cache invalidates.
+      - name: compute representative poetry versions
+        id: versions
+        run: |
+          list=$(curl -fsSL https://pypi.org/pypi/poetry/json \
+            | grep -o '"[0-9]*\.[0-9]*\.[0-9]*"' | tr -d '"' \
+            | awk -F. '$1 > 1 || ($1 == 1 && $2 >= 2)' \
+            | sort -V -u \
+            | awk -F. '{ v[$1"."$2] = $0 } END { for (k in v) print v[k] }' \
+            | sort -V)
+
+          echo "selected versions:"
+          echo "$list" | sed 's/^/  /'
+
+          {
+            echo "list<<EOF"
+            echo "$list"
+            echo "EOF"
+            echo "hash=$(echo "$list" | sha256sum | cut -d' ' -f1)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: cache installed poetry versions
+        id: cache
+        uses: actions/cache@v5
+        with:
+          path: ${{ runner.temp }}/poetryenv-real/.poetryenv/versions
+          key: poetry-versions-${{ runner.os }}-py3.11-${{ hashFiles('libexec/poetryenv-install', 'libexec/poetryenv--lib') }}-${{ steps.versions.outputs.hash }}
+
+      - name: install poetry versions
+        env:
+          POETRYENV_ROOT: ${{ runner.temp }}/poetryenv-real/.poetryenv
+        run: |
+          echo "cache-hit: ${{ steps.cache.outputs.cache-hit }}"
+          xargs ./bin/poetryenv install <<< '${{ steps.versions.outputs.list }}'
+
+      - name: integration tests
+        env:
+          POETRYENV_ROOT: ${{ runner.temp }}/poetryenv-real/.poetryenv
+        run: bash test/run.sh --integration -f

--- a/libexec/poetryenv--lib
+++ b/libexec/poetryenv--lib
@@ -4,6 +4,11 @@ export POETRYENV_VERSION="0.1.1"
 export POETRYENV_ROOT="${POETRYENV_ROOT:-$HOME/.poetryenv}"
 export POETRYENV_GLOBAL_FILE="$POETRYENV_ROOT/global"
 export POETRYENV_VERSIONS_DIR="$POETRYENV_ROOT/versions"
+
+# Minimum Poetry version that supports POETRY_CONFIG_DIR / POETRY_DATA_DIR /
+# POETRY_CACHE_DIR (PR python-poetry/poetry#5301, released in 1.2.0). Earlier
+# versions silently ignore those env vars, so per-version isolation breaks.
+export POETRYENV_MIN_SUPPORTED_VERSION="1.2.0"
 if [[ -z "${NO_COLOR}" ]] && [[ -t 1 ]]; then
     RED='\033[0;31m'
     GREEN='\033[0;32m'
@@ -39,6 +44,25 @@ warn() {
 normalize_version() {
     local version="$1"
     echo "$version" | sed -E 's/^([0-9]+\.[0-9]+).*/\1/'
+}
+
+# Returns 0 if $1 (a version like "1.8.5" or "2.0.0b1") is >= 1.2.0, else 1.
+# Only major/minor are inspected; non-digit suffixes on minor (e.g. "0b1") are
+# stripped so pre-release versions resolve to their base minor.
+version_supports_isolation() {
+    local version="$1"
+    local major="${version%%.*}"
+    local rest="${version#*.}"
+    local minor="${rest%%.*}"
+    major="${major//[!0-9]/}"
+    minor="${minor//[!0-9]/}"
+
+    [[ -z "$major" || -z "$minor" ]] && return 1
+
+    if (( major > 1 )) || { (( major == 1 )) && (( minor >= 2 )); }; then
+        return 0
+    fi
+    return 1
 }
 
 setup_poetry_env() {

--- a/libexec/poetryenv-install
+++ b/libexec/poetryenv-install
@@ -18,10 +18,10 @@ list_versions() {
     echo
 
     if command -v curl &>/dev/null; then
-        local releases=$(curl -s https://pypi.org/pypi/poetry/json | grep -o '"[0-9]*\.[0-9]*\.[0-9]*"' | tr -d '"' | awk -F. '$1 >= 1' | sort -V | uniq)
+        local releases=$(curl -s https://pypi.org/pypi/poetry/json | grep -o '"[0-9]*\.[0-9]*\.[0-9]*"' | tr -d '"' | awk -F. '$1 > 1 || ($1 == 1 && $2 >= 2)' | sort -V | uniq)
 
         if [[ -n "$releases" ]]; then
-            echo "Available Poetry versions (1.0+):"
+            echo "Available Poetry versions (${POETRYENV_MIN_SUPPORTED_VERSION}+):"
             echo
 
             local current_major=""
@@ -50,6 +50,10 @@ install_version() {
     local version="$1"
 
     [[ -z "$version" ]] && error "Version required. Usage: poetryenv install <version>"
+
+    if ! version_supports_isolation "$version"; then
+        error "Poetry ${version} is not supported. poetryenv requires Poetry >= ${POETRYENV_MIN_SUPPORTED_VERSION} because POETRY_CONFIG_DIR / POETRY_DATA_DIR / POETRY_CACHE_DIR (used for per-version isolation) were introduced in 1.2."
+    fi
 
     local install_dir="$POETRYENV_VERSIONS_DIR/${version}"
 

--- a/test/mock_isolation.bats
+++ b/test/mock_isolation.bats
@@ -1,5 +1,9 @@
 #!/usr/bin/env bats
-# Environment variable isolation tests
+# Isolation logic tests (mock-based).
+#
+# Verifies setup_poetry_env() and the per-version directory layout in a mock
+# environment. For verifying that a real Poetry binary actually honors
+# POETRY_CONFIG_DIR / POETRY_CACHE_DIR, see real_isolation.bats.
 
 load helpers/test_helper
 

--- a/test/real_isolation.bats
+++ b/test/real_isolation.bats
@@ -1,0 +1,154 @@
+#!/usr/bin/env bats
+# Real-install isolation tests.
+#
+# For every Poetry version already installed under POETRYENV_ROOT, verify that
+# the Poetry binary actually honors POETRY_CONFIG_DIR / POETRY_DATA_DIR /
+# POETRY_CACHE_DIR — i.e. that per-version isolation works for real, not just
+# in theory. POETRYENV_ROOT defaults to ~/.poetryenv (same as poetryenv itself).
+#
+# This file does NOT install Poetry, and does NOT write to the user's real
+# config. Each version is probed via a private temp config dir that bats
+# cleans up automatically.
+
+setup_file() {
+    # Mirror the fallback used by libexec/poetryenv--lib.
+    : "${POETRYENV_ROOT:=$HOME/.poetryenv}"
+    export POETRYENV_ROOT
+
+    if [[ ! -d "$POETRYENV_ROOT/versions" ]]; then
+        export REAL_ISOLATION_SKIP="$POETRYENV_ROOT/versions does not exist — run 'poetryenv install <version>' first"
+        export INSTALLED_VERSIONS_LIST=""
+        return 0
+    fi
+
+    local list=()
+    local d
+    for d in "$POETRYENV_ROOT/versions"/*; do
+        [[ -d "$d" && -x "$d/bin/poetry" ]] && list+=("$(basename "$d")")
+    done
+
+    if (( ${#list[@]} == 0 )); then
+        export REAL_ISOLATION_SKIP="no installed versions under $POETRYENV_ROOT/versions"
+        export INSTALLED_VERSIONS_LIST=""
+        return 0
+    fi
+
+    # Bash arrays can't be exported, so stash the joined string instead.
+    export INSTALLED_VERSIONS_LIST="${list[*]}"
+    export PROBE_DIR="${BATS_FILE_TMPDIR}/probe"
+    mkdir -p "$PROBE_DIR"
+}
+
+# Probe one installed Poetry version using a private throw-away config tree
+# under $PROBE_DIR. Verifies:
+#   1. POETRY_CONFIG_DIR is honored — poetry reads from the dir we point at
+#      (we pre-seed a marker value and read it back)
+#   2. POETRY_CACHE_DIR is honored — surfaces in `poetry config --list`
+# The user's real ~/.poetryenv/versions/<v>/config is never touched.
+assert_version_isolated() {
+    local version="$1"
+    local poetry_bin="$POETRYENV_ROOT/versions/$version/bin/poetry"
+
+    [[ -x "$poetry_bin" ]] || {
+        echo "[$version] poetry binary missing at $poetry_bin"
+        return 1
+    }
+
+    local probe_root="$PROBE_DIR/$version"
+    local probe_config="$probe_root/config"
+    local probe_data="$probe_root/data"
+    local probe_cache="$probe_root/cache"
+    local marker="$probe_root/marker-virtualenvs"
+    mkdir -p "$probe_config" "$probe_data" "$probe_cache"
+
+    cat >"$probe_config/config.toml" <<EOF
+[virtualenvs]
+path = "$marker"
+EOF
+
+    # 1. POETRY_CONFIG_DIR honored: poetry should read back our marker.
+    local actual
+    actual=$(POETRY_CONFIG_DIR="$probe_config" \
+        POETRY_DATA_DIR="$probe_data" \
+        POETRY_CACHE_DIR="$probe_cache" \
+        "$poetry_bin" config virtualenvs.path 2>&1) || true
+
+    if [[ "$actual" != "$marker" ]]; then
+        echo "[$version] POETRY_CONFIG_DIR ignored: expected $marker, got: $actual"
+        return 1
+    fi
+
+    # 2. POETRY_CACHE_DIR honored: surfaces in `poetry config --list`.
+    local listing
+    listing=$(POETRY_CONFIG_DIR="$probe_config" \
+        POETRY_DATA_DIR="$probe_data" \
+        POETRY_CACHE_DIR="$probe_cache" \
+        "$poetry_bin" config --list 2>&1) || true
+
+    if ! grep -q "$probe_cache" <<<"$listing"; then
+        echo "[$version] POETRY_CACHE_DIR not in 'poetry config --list':"
+        echo "$listing" | sed 's/^/    /'
+        return 1
+    fi
+
+    return 0
+}
+
+@test "POETRYENV_ROOT contains at least one installed version" {
+    [[ -z "${REAL_ISOLATION_SKIP:-}" ]] || skip "$REAL_ISOLATION_SKIP"
+    [[ -n "$INSTALLED_VERSIONS_LIST" ]] || {
+        echo "no installed versions under $POETRYENV_ROOT/versions"
+        false
+    }
+    # FD 3 is bats' "always show" channel; visible on PASS too.
+    echo "# POETRYENV_ROOT=$POETRYENV_ROOT" >&3
+    echo "# versions under test: $INSTALLED_VERSIONS_LIST" >&3
+}
+
+@test "every installed version honours POETRY_CONFIG_DIR / POETRY_CACHE_DIR" {
+    [[ -z "${REAL_ISOLATION_SKIP:-}" ]] || skip "$REAL_ISOLATION_SKIP"
+
+    local fails=()
+    local v
+    for v in $INSTALLED_VERSIONS_LIST; do
+        if assert_version_isolated "$v"; then
+            echo "#   PASS $v" >&3
+        else
+            echo "#   FAIL $v" >&3
+            fails+=("$v")
+        fi
+    done
+
+    if (( ${#fails[@]} > 0 )); then
+        echo "isolation failed for: ${fails[*]}"
+        false
+    fi
+}
+
+@test "two probe configs for the same version stay independent" {
+    # Sanity check: writing distinct marker values via two different
+    # POETRY_CONFIG_DIRs must not bleed into each other. This catches the
+    # failure mode where POETRY_CONFIG_DIR is silently ignored (the second
+    # write would clobber the first, or both reads return the same value).
+    [[ -z "${REAL_ISOLATION_SKIP:-}" ]] || skip "$REAL_ISOLATION_SKIP"
+
+    local versions=($INSTALLED_VERSIONS_LIST)
+    local v="${versions[0]}"
+    local poetry_bin="$POETRYENV_ROOT/versions/$v/bin/poetry"
+
+    local pa="$PROBE_DIR/_pair/a" pb="$PROBE_DIR/_pair/b"
+    mkdir -p "$pa" "$pb"
+    printf '[virtualenvs]\npath = "%s"\n' "$pa/marker-A" >"$pa/config.toml"
+    printf '[virtualenvs]\npath = "%s"\n' "$pb/marker-B" >"$pb/config.toml"
+
+    local got_a got_b
+    got_a=$(POETRY_CONFIG_DIR="$pa" "$poetry_bin" config virtualenvs.path 2>&1)
+    got_b=$(POETRY_CONFIG_DIR="$pb" "$poetry_bin" config virtualenvs.path 2>&1)
+
+    [[ "$got_a" == "$pa/marker-A" ]] || {
+        echo "config A read back wrong: $got_a"; false
+    }
+    [[ "$got_b" == "$pb/marker-B" ]] || {
+        echo "config B read back wrong: $got_b"; false
+    }
+}

--- a/test/run.sh
+++ b/test/run.sh
@@ -11,98 +11,89 @@ NC='\033[0m'
 
 show_help() {
     cat <<EOF
-Usage: ./test.sh [options] [test-file]
+Usage: ./test.sh [mode] [verbosity] [test-file]
 
-Options:
+Modes (mutually exclusive — last one wins):
+    --unit              Run unit tests (default)
+    --integration       Run integration tests
+    --all               Run both
+
+Verbosity:
+    -v, --verbose       Show all test output
+    -f, --failed        Print output only when a test fails
+    -t, --trace         Detailed trace
+
+Other:
     -h, --help          Show this help
-    -v, --verbose       Verbose output (show all test output)
-    -f, --failed        Only show failed tests details
-    -t, --trace         Show detailed trace (like Python traceback)
 
 Examples:
-    ./test.sh                           # Run all tests
-    ./test.sh test/basic.bats           # Run specific test file
-    ./test.sh -v                        # Run all tests with verbose output
-    ./test.sh -f test/global_local.bats # Run with failure details
-    ./test.sh -t                        # Run with detailed trace
-
-Test files:
-    test/basic.bats              - Basic functionality tests
-    test/version_management.bats - Install/uninstall tests
-    test/global.bats             - Global version tests
-    test/local.bats              - Local version tests
-    test/shim.bats               - Poetry shim tests
-    test/version_isolation.bats  - Version isolation tests
-    test/integration.bats        - Integration workflow tests
+    ./test.sh                           # Unit (default)
+    ./test.sh --integration             # Integration only
+    ./test.sh --all                     # Both
+    ./test.sh test/basic.bats           # A specific file
+    ./test.sh -v                        # Unit, verbose
 EOF
 }
 
-# Parse arguments
+UNIT_TESTS=(
+    "test/basic.bats"
+    "test/version_management.bats"
+    "test/global.bats"
+    "test/local.bats"
+    "test/mock_isolation.bats"
+    "test/shim.bats"
+    "test/workflow.bats"
+)
+
+INTEGRATION_TESTS=(
+    "test/real_isolation.bats"
+)
+
 VERBOSE=0
 FAILED_ONLY=0
 TRACE=0
-TEST_PATH="test/"
+MODE="unit"
+EXPLICIT_FILE=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        -h|--help)
-            show_help
-            exit 0
-            ;;
-        -v|--verbose)
-            VERBOSE=1
-            shift
-            ;;
-        -f|--failed)
-            FAILED_ONLY=1
-            shift
-            ;;
-        -t|--trace)
-            TRACE=1
-            shift
-            ;;
-        *)
-            TEST_PATH="$1"
-            shift
-            ;;
+        -h|--help)        show_help; exit 0 ;;
+        --unit)           MODE="unit"; shift ;;
+        --integration)    MODE="integration"; shift ;;
+        --all)            MODE="all"; shift ;;
+        -v|--verbose)     VERBOSE=1; shift ;;
+        -f|--failed)      FAILED_ONLY=1; shift ;;
+        -t|--trace)       TRACE=1; shift ;;
+        *)                EXPLICIT_FILE="$1"; shift ;;
     esac
 done
 
-# Build bats command
-BATS_CMD="bats"
-
-# Define the desired order of test execution
-# If a specific test file is passed as an argument, only that file will be run.
-if [[ "$TEST_PATH" != "test/" ]]; then
-    TEST_TARGETS=("$TEST_PATH")
+if [[ -n "$EXPLICIT_FILE" ]]; then
+    TEST_TARGETS=("$EXPLICIT_FILE")
 else
-    TEST_TARGETS=(
-        "test/basic.bats"
-        "test/version_management.bats"
-        "test/global.bats"
-        "test/local.bats"
-        "test/version_isolation.bats"
-        "test/shim.bats"
-        "test/integration.bats"
-    )
+    case "$MODE" in
+        unit)        TEST_TARGETS=("${UNIT_TESTS[@]}") ;;
+        integration) TEST_TARGETS=("${INTEGRATION_TESTS[@]}") ;;
+        all)         TEST_TARGETS=("${UNIT_TESTS[@]}" "${INTEGRATION_TESTS[@]}") ;;
+    esac
 fi
 
+BATS_CMD="bats"
 if [[ $TRACE -eq 1 ]]; then
-    # Most detailed output - like Python traceback
     BATS_CMD="$BATS_CMD --print-output-on-failure --show-output-of-passing-tests --verbose-run --trace"
 elif [[ $VERBOSE -eq 1 ]]; then
-    # Verbose output - show ALL test outputs (passing and failing)
     BATS_CMD="$BATS_CMD --show-output-of-passing-tests --verbose-run"
 elif [[ $FAILED_ONLY -eq 1 ]]; then
-    # Only show failures - like Python traceback
     BATS_CMD="$BATS_CMD --print-output-on-failure"
 fi
 
-# Add formatter for better readability
-BATS_CMD="$BATS_CMD --formatter pretty"
+# `pretty` calls tput and breaks on non-TTY stdout (CI runners have no $TERM).
+# Fall back to the default TAP formatter when not attached to a terminal.
+if [[ -t 1 ]]; then
+    BATS_CMD="$BATS_CMD --formatter pretty"
+fi
 
-# Run tests
-printf "${GREEN}→ Running tests...${NC}\n"
+printf "${GREEN}→ Running tests (${MODE})...${NC}\n"
 printf "${YELLOW}Command: ${BATS_CMD} ${TEST_TARGETS[*]}${NC}\n\n"
 
 if $BATS_CMD "${TEST_TARGETS[@]}"; then

--- a/test/version_management.bats
+++ b/test/version_management.bats
@@ -38,6 +38,74 @@ teardown() {
     [[ "$output" =~ "Available Poetry versions" ]]
 }
 
+@test "poetryenv install --list excludes versions before 1.2" {
+    run poetryenv install --list
+    [ "$status" -eq 0 ]
+    # 1.0.x and 1.1.x lack POETRY_CONFIG_DIR/DATA_DIR/CACHE_DIR support
+    # so they must not be advertised as available.
+    ! [[ "$output" =~ $'\n  1.0.' ]]
+    ! [[ "$output" =~ $'\n  1.1.' ]]
+    # Header should announce the lower bound.
+    [[ "$output" =~ "1.2.0+" ]]
+}
+
+@test "poetryenv install rejects 1.0.x" {
+    run poetryenv install 1.0.10
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "not supported" ]]
+    [[ "$output" =~ "1.2.0" ]]
+    # No directory should have been created.
+    [ ! -d "${POETRYENV_ROOT}/versions/1.0.10" ]
+}
+
+@test "poetryenv install rejects 1.1.x" {
+    run poetryenv install 1.1.15
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "not supported" ]]
+    [ ! -d "${POETRYENV_ROOT}/versions/1.1.15" ]
+}
+
+@test "poetryenv install rejects unsupported version before touching network" {
+    # If the version check ran AFTER curl/python checks, we might hit
+    # a different error first. Verify the 'not supported' message comes
+    # out specifically for an unsupported version.
+    run poetryenv install 1.1.0
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "not supported" ]]
+    # Should NOT have attempted to invoke the official installer.
+    ! [[ "$output" =~ "Downloading Poetry installer" ]]
+}
+
+@test "poetryenv install with multiple versions stops at unsupported" {
+    # First arg is unsupported; install must fail before processing the rest.
+    run poetryenv install 1.0.0 1.8.5
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "not supported" ]]
+    [ ! -d "${POETRYENV_ROOT}/versions/1.0.0" ]
+    [ ! -d "${POETRYENV_ROOT}/versions/1.8.5" ]
+}
+
+@test "version_supports_isolation accepts 1.2.0 and above" {
+    source libexec/poetryenv--lib
+
+    version_supports_isolation 1.2.0
+    version_supports_isolation 1.2.3
+    version_supports_isolation 1.8.5
+    version_supports_isolation 2.0.0
+    version_supports_isolation 2.4.0
+    version_supports_isolation 2.0.0b1
+}
+
+@test "version_supports_isolation rejects 1.1 and below" {
+    source libexec/poetryenv--lib
+
+    ! version_supports_isolation 1.0.0
+    ! version_supports_isolation 1.0.10
+    ! version_supports_isolation 1.1.0
+    ! version_supports_isolation 1.1.15
+    ! version_supports_isolation 0.12.17
+}
+
 @test "poetryenv install <version> installs poetry" {
     mock_install_poetry 1.8.5
     [ -d "${POETRYENV_ROOT}/versions/1.8.5" ]

--- a/test/workflow.bats
+++ b/test/workflow.bats
@@ -1,5 +1,9 @@
 #!/usr/bin/env bats
-# Integration tests - complete workflows
+# Workflow tests — multi-step poetryenv flows in a mock environment.
+#
+# These exercise install → global → local → use compositions without touching
+# the real PyPI installer. Despite the historical name "integration", these
+# are unit-level tests; real-install integration lives in real_isolation.bats.
 
 load helpers/test_helper
 


### PR DESCRIPTION
  POETRY_CONFIG_DIR / DATA_DIR / CACHE_DIR were introduced in Poetry 1.2
  (python-poetry/poetry#5301); 1.0 / 1.1 silently ignore them, so isolation
  breaks. Reject those versions from install and drop them from --list.

  Add real-install bats that probe the Poetry binary directly, split the
  suite into unit / integration, and wire up a PR workflow that caches
  installed versions keyed on PyPI's latest-patch-per-minor list.